### PR TITLE
fix: clarify 404 error meaning - no captions vs video not found

### DIFF
--- a/clawhub/transcript/SKILL.md
+++ b/clawhub/transcript/SKILL.md
@@ -94,7 +94,7 @@ Accepts: full URLs (`youtube.com/watch?v=ID`), short URLs (`youtu.be/ID`), short
 | ---- | ------------- | ----------------------------------- |
 | 401  | Bad API key   | Check key or re-setup               |
 | 402  | No credits    | Top up at transcriptapi.com/billing |
-| 404  | No transcript | Video may not have captions enabled |
+| 404  | No transcript | Video exists but has no captions. Public videos often lack captions. |
 | 408  | Timeout       | Retry once after 2s                 |
 | 429  | Rate limited  | Wait and retry                      |
 

--- a/clawhub/video-transcript/SKILL.md
+++ b/clawhub/video-transcript/SKILL.md
@@ -103,7 +103,7 @@ Accepted URL formats:
 | ---- | ------------- | ----------------------------------- |
 | 401  | Bad API key   | Check key or re-setup               |
 | 402  | No credits    | Top up at transcriptapi.com/billing |
-| 404  | No transcript | Video may not have captions enabled |
+| 404  | No transcript | Video exists but has no captions. Public videos often lack captions. |
 | 408  | Timeout       | Retry once after 2s                 |
 
 1 credit per successful request. Errors don't consume credits. Free tier: 100 credits, 300 req/min.

--- a/skills/transcript/SKILL.md
+++ b/skills/transcript/SKILL.md
@@ -48,6 +48,8 @@ curl -s "https://transcriptapi.com/api/v2/youtube/transcript\
 
 Accepts: full URLs (`youtube.com/watch?v=ID`), short URLs (`youtu.be/ID`), shorts (`youtube.com/shorts/ID`), or bare video IDs.
 
+> **Prerequisite:** Before requesting a transcript, verify the video has captions available. On YouTube, click the "Transcript" button below the video. If no transcript button appears, the video doesn't have captions and the API will return 404.
+
 **Default:** Always use `format=text&include_timestamp=true&send_metadata=true` unless user specifies otherwise.
 
 **Response** (`format=json`):
@@ -82,13 +84,15 @@ Accepts: full URLs (`youtube.com/watch?v=ID`), short URLs (`youtu.be/ID`), short
 
 ## Errors
 
-| Code | Meaning       | Action                              |
-| ---- | ------------- | ----------------------------------- |
-| 401  | Bad API key   | Check key or re-setup               |
-| 402  | No credits    | Top up at transcriptapi.com/billing |
-| 404  | No transcript | Video may not have captions enabled |
-| 408  | Timeout       | Retry once after 2s                 |
-| 429  | Rate limited  | Wait and retry                      |
+| Code | Meaning              | Action                                                                                                                                                                                                 |
+| ---- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 401  | Bad API key          | Check key or re-setup                                                                                                                                                                                  |
+| 402  | No credits           | Top up at transcriptapi.com/billing                                                                                                                                                                   |
+| 404  | No transcript avail | Video exists but has no captions/subtitles. **This is common** — public videos often don't have captions enabled. Check YouTube directly: click the transcript button under the video. |
+| 408  | Timeout              | Retry once after 2s                                                                                                                                                                                    |
+| 429  | Rate limited         | Wait and retry                                                                                                                                                                                        |
+
+> **Why does my video return 404 even though it's public?** A public video may not have captions enabled. YouTube requires either auto-generated captions (which may fail for poor audio) or manually uploaded subtitles. The transcript API cannot generate captions from audio — it can only retrieve existing caption tracks.
 
 ## Tips
 

--- a/skills/transcriptapi/SKILL.md
+++ b/skills/transcriptapi/SKILL.md
@@ -270,14 +270,16 @@ curl -s "https://transcriptapi.com/api/v2/youtube/playlist/videos?continuation=T
 
 ## Errors
 
-| Code | Meaning           | Action                                              |
-| ---- | ----------------- | --------------------------------------------------- |
-| 401  | Bad API key       | Check key, re-run setup                             |
-| 402  | No credits        | Top up at transcriptapi.com/billing                 |
-| 404  | Not found         | Video/channel/playlist doesn't exist or no captions |
-| 408  | Timeout/retryable | Retry once after 2s                                 |
-| 422  | Validation error  | Check param format                                  |
-| 429  | Rate limited      | Wait, respect Retry-After                           |
+| Code | Meaning                | Action                                                                                                                                                                                                                   |
+| ---- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 401  | Bad API key            | Check key, re-run setup                                                                                                                                                                                                   |
+| 402  | No credits             | Top up at transcriptapi.com/billing                                                                                                                                                                                       |
+| 404  | No transcript available | Video/channel/playlist exists but has no captions. **This is common** — public videos often don't have captions. Check YouTube directly for the video. |
+| 408  | Timeout/retryable      | Retry once after 2s                                                                                                                                                                                                       |
+| 422  | Validation error       | Check param format                                                                                                                                                                                                        |
+| 429  | Rate limited           | Wait, respect Retry-After                                                                                                                                                                                                 |
+
+> **Why does my video return 404 even though it's public?** A public video may not have captions enabled. YouTube requires either auto-generated captions (which may fail for poor audio) or manually uploaded subtitles. The transcript API cannot generate captions from audio — it can only retrieve existing caption tracks.
 
 ## Tips
 

--- a/skills/video-transcript/SKILL.md
+++ b/skills/video-transcript/SKILL.md
@@ -95,7 +95,7 @@ Accepted URL formats:
 | ---- | ------------- | ----------------------------------- |
 | 401  | Bad API key   | Check key or re-setup               |
 | 402  | No credits    | Top up at transcriptapi.com/billing |
-| 404  | No transcript | Video may not have captions enabled |
+| 404  | No transcript | Video exists but has no captions. Public videos often lack captions. |
 | 408  | Timeout       | Retry once after 2s                 |
 
 1 credit per successful request. Errors don't consume credits. Free tier: 100 credits, 300 req/min.

--- a/skills/youtube-full/SKILL.md
+++ b/skills/youtube-full/SKILL.md
@@ -61,6 +61,8 @@ curl -s "https://transcriptapi.com/api/v2/youtube/transcript\
 }
 ```
 
+> **Note:** If you get a 404 error, the video exists but has no available captions. This is common for public videos — YouTube doesn't auto-generate captions for all videos, especially those with poor audio quality or in certain languages.
+
 ## Search — 1 credit
 
 ```bash
@@ -162,14 +164,16 @@ Valid ID prefixes: `PL`, `UU`, `LL`, `FL`, `OL`. Response includes `playlist_inf
 
 ## Errors
 
-| Code | Meaning          | Action                                |
-| ---- | ---------------- | ------------------------------------- |
-| 401  | Bad API key      | Check key                             |
-| 402  | No credits       | transcriptapi.com/billing             |
-| 404  | Not found        | Resource doesn't exist or no captions |
-| 408  | Timeout          | Retry once after 2s                   |
-| 422  | Validation error | Check param format                    |
-| 429  | Rate limited     | Wait, respect Retry-After             |
+| Code | Meaning                   | Action                                                                                                                                                                                                 |
+| ---- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 401  | Bad API key              | Check key                                                                                                                                                                                              |
+| 402  | No credits               | Top up at transcriptapi.com/billing                                                                                                                                                                   |
+| 404  | No transcript available  | Video exists but has no captions/subtitles. **This is the most common cause** — public videos often don't have captions. Check YouTube directly: click the transcript button under the video. |
+| 408  | Timeout                  | Retry once after 2s                                                                                                                                                                                    |
+| 422  | Validation error          | Check param format                                                                                                                                                                                     |
+| 429  | Rate limited              | Wait, respect Retry-After                                                                                                                                                                              |
+
+> **Why does my video return 404 even though it's public?** A public video may not have captions enabled. YouTube requires either auto-generated captions (which may fail for poor audio) or manually uploaded subtitles. The transcript API cannot generate captions from audio — it can only retrieve existing caption tracks.
 
 ## Typical Workflows
 


### PR DESCRIPTION
The 404 error was confusing users because they see 'not found' and assume the video doesn't exist, when actually 404 means 'no captions available'.

This fix:
- Clarifies that 404 means 'no transcript available' not 'video not found'
- Explains that public videos often don't have captions enabled
- Adds a prerequisite note about checking for captions on YouTube first
- Provides actionable guidance when 404 is returned

The issue was that users were confused when getting 404 for public videos like https://www.youtube.com/watch?v=Th8JoIan4dg - the video exists but has no captions enabled, which is common for many YouTube videos.