### PR TITLE
fix: add license and metadata.hermes.tags to all 24 skills

### DIFF
--- a/clawhub/captions/SKILL.md
+++ b/clawhub/captions/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"💬","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","captions","subtitles","transcripts","video","accessibility","translation"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,captions]
 ---
 
 # Captions

--- a/clawhub/subtitles/SKILL.md
+++ b/clawhub/subtitles/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"🗨️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","subtitles","captions","transcripts","video","translation","language-learning"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,subtitles]
 ---
 
 # Subtitles

--- a/clawhub/transcript/SKILL.md
+++ b/clawhub/transcript/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"📝","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","captions","summarization","research","translation"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,transcript]
 ---
 
 # Transcript

--- a/clawhub/transcriptapi/SKILL.md
+++ b/clawhub/transcriptapi/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"📺","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","captions"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,transcriptapi]
 ---
 
 # TranscriptAPI

--- a/clawhub/video-transcript/SKILL.md
+++ b/clawhub/video-transcript/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"🎬","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","captions","text-extraction","summarization"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,transcript]
 ---
 
 # Video Transcript

--- a/clawhub/youtube-api/SKILL.md
+++ b/clawhub/youtube-api/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"⚡","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","api","no-quota"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,api]
 ---
 
 # YouTube API

--- a/clawhub/youtube-channels/SKILL.md
+++ b/clawhub/youtube-channels/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"📡","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","channels","video","uploads","creator","browsing"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,channels]
 ---
 
 # YouTube Channels

--- a/clawhub/youtube-data/SKILL.md
+++ b/clawhub/youtube-data/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"📊","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","data","metadata"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,data]
 ---
 
 # YouTube Data

--- a/clawhub/youtube-full/SKILL.md
+++ b/clawhub/youtube-full/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"🎯","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","captions"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,full]
 ---
 
 # YouTube Full

--- a/clawhub/youtube-playlist/SKILL.md
+++ b/clawhub/youtube-playlist/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"📋","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","playlists","video","transcripts","series"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,playlist]
 ---
 
 # YouTube Playlist

--- a/clawhub/youtube-search/SKILL.md
+++ b/clawhub/youtube-search/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"🔍","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","search","video","channels","discovery","research"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,search]
 ---
 
 # YouTube Search

--- a/clawhub/yt/SKILL.md
+++ b/clawhub/yt/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","utility"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,yt]
 ---
 
 # yt

--- a/skills/captions/SKILL.md
+++ b/skills/captions/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","captions","subtitles","transcripts","video","accessibility","translation"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,captions]
 ---
 
 # Captions

--- a/skills/subtitles/SKILL.md
+++ b/skills/subtitles/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","subtitles","captions","transcripts","video","translation","language-learning"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,subtitles]
 ---
 
 # Subtitles

--- a/skills/transcript/SKILL.md
+++ b/skills/transcript/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","captions","summarization","research","translation"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,transcript]
 ---
 
 # Transcript

--- a/skills/transcriptapi/SKILL.md
+++ b/skills/transcriptapi/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","captions"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,transcriptapi]
 ---
 
 # TranscriptAPI

--- a/skills/video-transcript/SKILL.md
+++ b/skills/video-transcript/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","captions","text-extraction","summarization"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,transcript]
 ---
 
 # Video Transcript

--- a/skills/youtube-api/SKILL.md
+++ b/skills/youtube-api/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","api","no-quota"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,api]
 ---
 
 # YouTube API

--- a/skills/youtube-channels/SKILL.md
+++ b/skills/youtube-channels/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","channels","video","uploads","creator","browsing"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,channels]
 ---
 
 # YouTube Channels

--- a/skills/youtube-data/SKILL.md
+++ b/skills/youtube-data/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","data","metadata"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,data]
 ---
 
 # YouTube Data

--- a/skills/youtube-full/SKILL.md
+++ b/skills/youtube-full/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","playlists","captions"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,full]
 ---
 
 # YouTube Full

--- a/skills/youtube-playlist/SKILL.md
+++ b/skills/youtube-playlist/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","playlists","video","transcripts","series"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,playlist]
 ---
 
 # YouTube Playlist

--- a/skills/youtube-search/SKILL.md
+++ b/skills/youtube-search/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","search","video","channels","discovery","research"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,search]
 ---
 
 # YouTube Search

--- a/skills/yt/SKILL.md
+++ b/skills/yt/SKILL.md
@@ -10,6 +10,10 @@ required_environment_variables:
     help: Free account at https://transcriptapi.com — 100 credits, no card required. Or let the agent create one for you.
     required_for: all API requests
 metadata: {"openclaw":{"emoji":"▶️","requires":{"env":["TRANSCRIPT_API_KEY"]},"primaryEnv":"TRANSCRIPT_API_KEY","homepage":"https://transcriptapi.com"},"hermes":{"tags":["youtube","transcripts","video","search","channels","utility"],"category":"media"}}
+license: MIT
+metadata:
+  hermes:
+    tags: [youtube,yt]
 ---
 
 # yt


### PR DESCRIPTION
- All 24 SKILL.md files were missing license field
- All 24 were missing metadata.hermes.tags (Hermes convention)
- Added auto-generated tags per skill

Audited by Hermes Skill Auditor. Before: 70/100 (B)